### PR TITLE
Fix Issue #3 - possibly others - Updated for Sketch API v4

### DIFF
--- a/Select Below.sketchplugin/Contents/Sketch/below-mouse.cocoascript
+++ b/Select Below.sketchplugin/Contents/Sketch/below-mouse.cocoascript
@@ -11,10 +11,10 @@ var onRun = function(context) {
   var handler = doc.eventHandlerManager().normalHandler();
   var page = doc.currentPage();
   var container = (page.currentArtboard()) ? page.currentArtboard() : page;
-  var point = handler.mouseInScreenCoordinatesInGroup(container);
+  var point = handler.currentMousePointInCanvasCoordinates();
 
   // for some reason, we need to add container y position to the calculation
-  var bottom = point.y + container.frame().y();
+  var bottom = point.y - container.frame().y();
 
   // set up the predicate and receive an array of matched layers
   // because Sketch gets confused when layers and their parent group are selected,
@@ -24,5 +24,5 @@ var onRun = function(context) {
   var queryResult = scope.filteredArrayUsingPredicate(predicate);
 
   // select all layers that match the query
-  doc.currentPage().selectLayers(queryResult);
+  doc.currentPage().changeSelectionBySelectingLayers(queryResult);
 };

--- a/Select Below.sketchplugin/Contents/Sketch/below-mouse.cocoascript
+++ b/Select Below.sketchplugin/Contents/Sketch/below-mouse.cocoascript
@@ -14,7 +14,7 @@ var onRun = function(context) {
   var point = handler.currentMousePointInCanvasCoordinates();
 
   // for some reason, we need to add container y position to the calculation
-  var bottom = point.y - container.frame().y();
+  var bottom = point.y + container.frame().y();
 
   // set up the predicate and receive an array of matched layers
   // because Sketch gets confused when layers and their parent group are selected,

--- a/Select Below.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Select Below.sketchplugin/Contents/Sketch/script.cocoascript
@@ -6,7 +6,7 @@ var onRun = function(context) {
   var selection = context.selection[0];
 
   // set the scope to the layer group that the currently selected layer is in
-  var scope = selection.parentGroup().layers().array();
+  var scope = selection.parentGroup().layers();
 
   // calculate the bottom position of the selected layer
   var bottom = selection.absoluteRect().y() + selection.absoluteRect().height();
@@ -16,5 +16,5 @@ var onRun = function(context) {
   var queryResult = scope.filteredArrayUsingPredicate(predicate);
 
   // select all layers that match the query
-  doc.currentPage().selectLayers(queryResult);
+  doc.currentPage().changeSelectionBySelectingLayers(queryResult);
 };


### PR DESCRIPTION
Below Selection
 - TypeError: selection.parentGroup().layers().array is not a function. (In 'selection.parentGroup().layers().array()', 'selection.parentGroup().layers().array' is undefined)
line: 9

Below Mouse
- TypeError: handler.mouseInScreenCoordinatesInGroup is not a function. (In 'handler.mouseInScreenCoordinatesInGroup(container)', 'handler.mouseInScreenCoordinatesInGroup' is undefined)
line: 14